### PR TITLE
  feat: implement Push to Talk across Web, iOS, and Android

### DIFF
--- a/apps/android/app/src/main/java/com/bedrud/app/ui/screens/meeting/MeetingScreen.kt
+++ b/apps/android/app/src/main/java/com/bedrud/app/ui/screens/meeting/MeetingScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.filled.MicOff
 import androidx.compose.material.icons.filled.ScreenShare
 import androidx.compose.material.icons.filled.StopScreenShare
 import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.VideocamOff
 import androidx.compose.material3.AlertDialog
@@ -429,7 +430,7 @@ fun MeetingScreen(
                                         }
                                     ) {
                                         Icon(
-                                            if (isPttActive) Icons.Default.GraphicEq else Icons.Default.Mic,
+                                            if (isPttActive) Icons.Default.GraphicEq else Icons.Default.RecordVoiceOver,
                                             contentDescription = "Push to Talk",
                                             tint = if (isPttActive)
                                                 MaterialTheme.colorScheme.onPrimary


### PR DESCRIPTION
                                                                                                                                                                                                                               
  Description:
  ## Summary                                                                                                                                                                                                                   
  - Adds hold-to-talk PTT button to meeting control bars on Web, iOS, and Android
  - PTT is a local mic gate: hold unmutes instantly, release restores toggle state after 250ms
  - Web: Space bar default keybind, configurable and persisted in `localStorage`                                                                                                                                               
  - All platforms: prominent "Transmitting..." floating overlay while held                                                                                                                                                     
  - No server changes, no LiveKit metadata — purely client-side (Discord pattern)                                                                                                                                              
                                                                                                                                                                                                                               
  ## Changes                                          
            
  **Web (Svelte)**
  - `PttButton.svelte` — hold button with pointer capture for reliable release detection
  - `PttOverlay.svelte` — fixed bottom-center "Transmitting..." indicator               
  - `+page.svelte` — PTT state/mic gate logic, keyboard listener (Space), settings UI for custom key
                                                                                                                                                                                                                               
  **iOS (SwiftUI)**
  - `RoomManager.swift` — `startPtt()` / `stopPtt()` with 250ms `Task.sleep` release delay                                                                                                                                     
  - `ControlBar.swift` — PTT hold button using `DragGesture(minimumDistance: 0)`          
  - `MeetingView.swift` — "Transmitting..." capsule overlay in root `ZStack`                                                                                                                                                   
                                                                                                                                                                                                                               
  **Android (Jetpack Compose)**
  - `RoomManager.kt` — `startPtt()` / `stopPtt()` with coroutine `delay(250)`, `managerScope` for reconnection safety                                                                                                          
  - `MeetingScreen.kt` — PTT `SmallFloatingActionButton` with `pointerInput` hold detection + overlay `Box`          
                                                                                                                                                                                                                               
  ## Test plan
  - [ ] Web: hold PTT button → overlay appears → mic transmits → release → overlay gone, mic restored                                                                                                                          
  - [ ] Web: Space bar triggers PTT when not typing in chat input                                    
  - [ ] Web: custom key persists across page reload                                                                                                                                                                            
  - [ ] iOS: hold PTT button on simulator → overlay shows → release → restores                                                                                                                                                 
  - [ ] Android: hold PTT on emulator → overlay shows → release → restores                                                                                                                                                     
  - [ ] All: mic toggle state is preserved (toggle off → PTT transmits → release → returns to muted)  