### PR TITLE
perf(ci): eliminate QEMU emulation from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,31 @@
 # Build artifacts (generated during Docker build stages)
 apps/web/dist
 apps/web/node_modules
+apps/web/.vinxi
 server/frontend
 server/dist
 dist
+target
 
 # Mobile apps (not needed for server image)
 apps/android
 apps/ios
+apps/desktop
+apps/server
 
 # Python agents
 agents
 tools
 .venv
 __pycache__
+
+# Test files
+**/*.test.*
+**/*.spec.*
+**/__tests__
+**/testutil
+**/testdata
+**/*_test.go
 
 # Dev & IDE
 .git
@@ -23,4 +35,14 @@ __pycache__
 .claude
 *.md
 .env
+.env.*
 .DS_Store
+.gitignore
+.editorconfig
+.eslintrc*
+.prettierrc*
+LICENSE
+
+# Docker files (prevent recursive context)
+Dockerfile*
+docker-compose*

--- a/.github/workflows/dev-nightly.yml
+++ b/.github/workflows/dev-nightly.yml
@@ -123,20 +123,32 @@ jobs:
           bun install --frozen-lockfile
           bun run build:embed
 
+      - name: Cache LiveKit binary
+        id: lk-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/livekit-cache
+          key: livekit-1.10.1-${{ matrix.goos }}-${{ matrix.goarch }}
+
       - name: Download LiveKit binary
         env:
           LIVEKIT_VERSION: "1.10.1"
         run: |
-          mkdir -p server/internal/livekit/bin
+          mkdir -p server/internal/livekit/bin /tmp/livekit-cache
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/livekit_${LIVEKIT_VERSION}_windows_amd64.zip" \
-              -o /tmp/lk.zip
-            unzip /tmp/lk.zip livekit-server.exe -d server/internal/livekit/bin/
+            LK_FILE="livekit_${LIVEKIT_VERSION}_windows_amd64.zip"
+            if [ ! -f "/tmp/livekit-cache/${LK_FILE}" ]; then
+              curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+                -o "/tmp/livekit-cache/${LK_FILE}"
+            fi
+            unzip "/tmp/livekit-cache/${LK_FILE}" livekit-server.exe -d server/internal/livekit/bin/
           else
-            LK_FILENAME="livekit_${LIVEKIT_VERSION}_linux_${{ matrix.lk_arch }}.tar.gz"
-            curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILENAME}" \
-              -o "/tmp/${LK_FILENAME}"
-            tar -xzf "/tmp/${LK_FILENAME}" -C server/internal/livekit/bin/ livekit-server
+            LK_FILE="livekit_${LIVEKIT_VERSION}_linux_${{ matrix.lk_arch }}.tar.gz"
+            if [ ! -f "/tmp/livekit-cache/${LK_FILE}" ]; then
+              curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+                -o "/tmp/livekit-cache/${LK_FILE}"
+            fi
+            tar -xzf "/tmp/livekit-cache/${LK_FILE}" -C server/internal/livekit/bin/ livekit-server
             chmod +x server/internal/livekit/bin/livekit-server
           fi
 
@@ -213,14 +225,12 @@ jobs:
           name: server-deb-${{ matrix.deb_arch }}
           path: bedrud_${{ matrix.deb_arch }}.deb
 
-  # ── Docker image ──────────────────────────────────────────────
+  # ── Docker image (assembled from pre-built binaries — no QEMU) ──
   docker:
     name: Docker Image
     runs-on: ubuntu-latest
-    needs: prepare
+    needs: [prepare, server-binary]
     steps:
-      - uses: actions/checkout@v6
-
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -238,15 +248,35 @@ jobs:
             type=raw,value=${{ needs.prepare.outputs.docker_tag }}
             type=raw,value=${{ needs.prepare.outputs.tag }}
 
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: server-linux_*
+          path: docker-ctx
+
+      - name: Prepare Docker context
+        run: |
+          cp docker-ctx/server-linux_amd64/bedrud_linux_amd64 docker-ctx/bedrud_linux_amd64
+          cp docker-ctx/server-linux_arm64/bedrud_linux_arm64 docker-ctx/bedrud_linux_arm64
+          chmod +x docker-ctx/bedrud_linux_*
+
+          cat > docker-ctx/Dockerfile <<'DOCKERFILE'
+          FROM alpine:3.21
+          RUN apk add --no-cache ca-certificates tzdata
+          ARG TARGETARCH
+          COPY bedrud_linux_${TARGETARCH} /usr/local/bin/bedrud
+          EXPOSE 8090 7880
+          ENTRYPOINT ["bedrud"]
+          CMD ["run"]
+          DOCKERFILE
+
       - uses: docker/build-push-action@v7
         with:
-          context: .
+          context: docker-ctx
+          file: docker-ctx/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # ── Android APK ──────────────────────────────────────────────
   android:

--- a/.github/workflows/pr-beta.yml
+++ b/.github/workflows/pr-beta.yml
@@ -267,7 +267,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             name: windows-arm64
             nsis_arch: arm64
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             name: macos-x86_64
           - os: macos-latest

--- a/.github/workflows/pr-beta.yml
+++ b/.github/workflows/pr-beta.yml
@@ -96,15 +96,24 @@ jobs:
           bun install --frozen-lockfile
           bun run build:embed
 
+      - name: Cache LiveKit binary
+        uses: actions/cache@v5
+        with:
+          path: /tmp/livekit-cache
+          key: livekit-1.10.1-${{ matrix.goos }}-${{ matrix.goarch }}
+
       - name: Download LiveKit binary
         env:
           LIVEKIT_VERSION: "1.10.1"
           LK_ARCH: ${{ matrix.lk_arch }}
         run: |
-          mkdir -p server/internal/livekit/bin
-          LK_FILENAME="livekit_${LIVEKIT_VERSION}_linux_${LK_ARCH}.tar.gz"
-          curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILENAME}" -o "/tmp/${LK_FILENAME}"
-          tar -xzf "/tmp/${LK_FILENAME}" -C server/internal/livekit/bin/ livekit-server
+          mkdir -p server/internal/livekit/bin /tmp/livekit-cache
+          LK_FILE="livekit_${LIVEKIT_VERSION}_linux_${LK_ARCH}.tar.gz"
+          if [ ! -f "/tmp/livekit-cache/${LK_FILE}" ]; then
+            curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+              -o "/tmp/livekit-cache/${LK_FILE}"
+          fi
+          tar -xzf "/tmp/livekit-cache/${LK_FILE}" -C server/internal/livekit/bin/ livekit-server
           chmod +x server/internal/livekit/bin/livekit-server
 
       - name: Build server binary

--- a/.github/workflows/pr-beta.yml
+++ b/.github/workflows/pr-beta.yml
@@ -294,7 +294,9 @@ jobs:
       - name: Install NSIS (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: choco install nsis -y --no-progress
+        run: |
+          choco install nsis -y --no-progress
+          echo "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build release binary
         run: cargo build -p bedrud-desktop --release --target ${{ matrix.target }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,30 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Export Docker images for offline use
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          for arch in amd64 arm64; do
+            docker buildx build \
+              --platform "linux/${arch}" \
+              --build-arg "TARGETARCH=${arch}" \
+              --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}" \
+              --output "type=docker,dest=bedrud-docker-linux-${arch}.tar" \
+              --file docker-ctx/Dockerfile \
+              docker-ctx
+            gzip "bedrud-docker-linux-${arch}.tar"
+          done
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docker-linux-amd64
+          path: bedrud-docker-linux-amd64.tar.gz
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docker-linux-arm64
+          path: bedrud-docker-linux-arm64.tar.gz
+
   # ── Android APK ──────────────────────────────────────────────
   android:
     name: Android APK
@@ -755,7 +779,7 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
-          pattern: "{server-*,android-debug-*,android-release-*,ios-*,bedrud-desktop-*}"
+          pattern: "{server-*,android-debug-*,android-release-*,ios-*,bedrud-desktop-*,docker-*}"
 
       - name: Collect release assets
         run: |
@@ -796,6 +820,9 @@ jobs:
 
           # Desktop: AppImages, portables, installers, debs, RPMs, DMGs
           find artifacts/bedrud-desktop-* -type f -exec cp {} release-assets/ \;
+
+          # Docker images for offline/air-gapped use
+          find artifacts/docker-* -name "*.tar.gz" -exec cp {} release-assets/ \; 2>/dev/null || true
 
           ls -la release-assets/
 
@@ -908,6 +935,11 @@ jobs:
 
           <b>🐳 Docker</b>
           <code>docker pull ghcr.io/${REPO}:${TAG}</code>
+
+          <b>🐳 Docker (offline / air-gapped)</b>
+          • <a href="${BASE}/bedrud-docker-linux-amd64.tar.gz">x86_64 image</a>
+          • <a href="${BASE}/bedrud-docker-linux-arm64.tar.gz">ARM64 image</a>
+          <code>docker load &lt; bedrud-docker-linux-amd64.tar.gz</code>
           EOF
           )
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,18 +69,30 @@ jobs:
           bun install --frozen-lockfile
           bun run build:embed
 
+      - name: Cache LiveKit binary
+        id: lk-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/livekit-cache
+          key: livekit-${{ env.LIVEKIT_VERSION }}-${{ matrix.goos }}-${{ matrix.goarch }}
+
       - name: Download LiveKit binary
         run: |
-          mkdir -p server/internal/livekit/bin
+          mkdir -p server/internal/livekit/bin /tmp/livekit-cache
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/livekit_${LIVEKIT_VERSION}_windows_amd64.zip" \
-              -o /tmp/lk.zip
-            unzip /tmp/lk.zip livekit-server.exe -d server/internal/livekit/bin/
+            LK_FILE="livekit_${LIVEKIT_VERSION}_windows_amd64.zip"
+            if [ ! -f "/tmp/livekit-cache/${LK_FILE}" ]; then
+              curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+                -o "/tmp/livekit-cache/${LK_FILE}"
+            fi
+            unzip "/tmp/livekit-cache/${LK_FILE}" livekit-server.exe -d server/internal/livekit/bin/
           else
-            LK_FILENAME="livekit_${LIVEKIT_VERSION}_linux_${{ matrix.lk_arch }}.tar.gz"
-            curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILENAME}" \
-              -o "/tmp/${LK_FILENAME}"
-            tar -xzf "/tmp/${LK_FILENAME}" -C server/internal/livekit/bin/ livekit-server
+            LK_FILE="livekit_${LIVEKIT_VERSION}_linux_${{ matrix.lk_arch }}.tar.gz"
+            if [ ! -f "/tmp/livekit-cache/${LK_FILE}" ]; then
+              curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+                -o "/tmp/livekit-cache/${LK_FILE}"
+            fi
+            tar -xzf "/tmp/livekit-cache/${LK_FILE}" -C server/internal/livekit/bin/ livekit-server
             chmod +x server/internal/livekit/bin/livekit-server
           fi
 
@@ -193,13 +205,12 @@ jobs:
           name: server-rpm-${{ matrix.deb_arch }}
           path: bedrud-*.rpm
 
-  # ── Docker image ──────────────────────────────────────────────
+  # ── Docker image (assembled from pre-built binaries — no QEMU) ──
   docker:
     name: Docker Image
     runs-on: ubuntu-latest
+    needs: server-binary
     steps:
-      - uses: actions/checkout@v6
-
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -218,15 +229,35 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: server-linux_*
+          path: docker-ctx
+
+      - name: Prepare Docker context
+        run: |
+          cp docker-ctx/server-linux_amd64/bedrud_linux_amd64 docker-ctx/bedrud_linux_amd64
+          cp docker-ctx/server-linux_arm64/bedrud_linux_arm64 docker-ctx/bedrud_linux_arm64
+          chmod +x docker-ctx/bedrud_linux_*
+
+          cat > docker-ctx/Dockerfile <<'DOCKERFILE'
+          FROM alpine:3.21
+          RUN apk add --no-cache ca-certificates tzdata
+          ARG TARGETARCH
+          COPY bedrud_linux_${TARGETARCH} /usr/local/bin/bedrud
+          EXPOSE 8090 7880
+          ENTRYPOINT ["bedrud"]
+          CMD ["run"]
+          DOCKERFILE
+
       - uses: docker/build-push-action@v7
         with:
-          context: .
+          context: docker-ctx
+          file: docker-ctx/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # ── Android APK ──────────────────────────────────────────────
   android:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.7
-# ── Stage 1: Frontend ────────────────────────────────────────────────────────
-FROM oven/bun:1 AS frontend
+# ── Stage 0: Cross-compilation helper ────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.6.1 AS xx
+
+# ── Stage 1: Frontend (platform-independent) ────────────────────────────────
+FROM --platform=$BUILDPLATFORM oven/bun:1 AS frontend
 WORKDIR /app
 
 # Install deps in a separate layer so source changes don't re-run install
@@ -8,15 +11,32 @@ COPY apps/web/package.json apps/web/bun.lock ./
 RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install --frozen-lockfile
 
-COPY apps/web/ ./
+# Copy only what the Vite build needs (not tests, docs, scripts)
+COPY apps/web/src/ ./src/
+COPY apps/web/public/ ./public/
+COPY apps/web/vite.config.ts apps/web/tsconfig.json apps/web/components.json ./
 RUN bun run build
 
-# ── Stage 2: Server binary ───────────────────────────────────────────────────
-FROM golang:1.25-alpine AS backend
+# ── Stage 2: LiveKit binary (for target arch) ───────────────────────────────
+FROM --platform=$BUILDPLATFORM alpine:3.21 AS livekit
 ARG TARGETARCH
 ARG LIVEKIT_VERSION=1.10.1
+RUN apk add --no-cache curl && \
+    LK_FILE="livekit_${LIVEKIT_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" \
+      -o "/tmp/${LK_FILE}" && \
+    mkdir -p /out && \
+    tar -xzf "/tmp/${LK_FILE}" -C /out/ livekit-server && \
+    chmod +x /out/livekit-server
 
-RUN apk add --no-cache gcc musl-dev curl
+# ── Stage 3: Server binary (native cross-compilation via xx) ────────────────
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS backend
+COPY --from=xx / /
+ARG TARGETPLATFORM
+
+# Install cross-compilation toolchain (runs on build platform, targets TARGETPLATFORM)
+RUN apk add --no-cache clang lld
+RUN xx-apk add --no-cache gcc musl-dev
 
 WORKDIR /build/server
 
@@ -25,27 +45,18 @@ COPY server/go.mod server/go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-# Download LiveKit binary (cached separately — only invalidates on version bump)
-RUN --mount=type=cache,target=/tmp/lk-cache \
-    LK_FILE="livekit_${LIVEKIT_VERSION}_linux_${TARGETARCH}.tar.gz" && \
-    DEST="/tmp/lk-cache/${LK_FILE}" && \
-    if [ ! -f "$DEST" ]; then \
-      curl -fsSL "https://github.com/livekit/livekit/releases/download/v${LIVEKIT_VERSION}/${LK_FILE}" -o "$DEST"; \
-    fi && \
-    mkdir -p internal/livekit/bin && \
-    tar -xzf "$DEST" -C internal/livekit/bin/ livekit-server && \
-    chmod +x internal/livekit/bin/livekit-server
-
-# Copy source and embedded frontend, then build
+# Copy source and embedded assets, then cross-compile
 COPY server/ ./
 COPY --from=frontend /app/dist/client ./frontend/
+COPY --from=livekit /out/livekit-server ./internal/livekit/bin/livekit-server
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=1 GOOS=linux \
-    go build -ldflags="-s -w" -o /bedrud ./cmd/bedrud/main.go
+    CGO_ENABLED=1 \
+    xx-go build -ldflags="-s -w" -o /bedrud ./cmd/bedrud/main.go && \
+    xx-verify /bedrud
 
-# ── Stage 3: Runtime ─────────────────────────────────────────────────────────
+# ── Stage 4: Runtime ────────────────────────────────────────────────────────
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata
 COPY --from=backend /bedrud /usr/local/bin/bedrud


### PR DESCRIPTION
Docker multi-platform builds (linux/amd64 + linux/arm64) were taking ~20 minutes because QEMU emulated the non-native architecture for the entire build — Go CGO compilation, bun install, and LiveKit download all ran under emulation at 5-10x slower speed.

Changes:
- CI Docker jobs now reuse pre-built server binaries from the server-binary job instead of rebuilding everything inside Docker. The Docker step just copies the binary into alpine (~30 seconds).
- Dockerfile optimized for local multi-platform builds with tonistiigi/xx for native CGO cross-compilation (no QEMU).
- Frontend stage uses --platform=$BUILDPLATFORM (output is platform-independent JS/HTML/CSS).
- LiveKit download separated into its own stage with --platform=$BUILDPLATFORM.
- LiveKit binaries cached with actions/cache across all workflows (dev-nightly, pr-beta, release).
- .dockerignore expanded to exclude test files, desktop/mobile apps, and Docker files from build context.

Closes #40