### PR TITLE
Fix dev build frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: help init dev dev-web dev-server dev-server-hot dev-api dev-livekit dev-ios dev-android dev-desktop build build-front build-back build-dist build-android-debug build-android install-android release-android build-ios export-ios build-ios-sim build-desktop deploy test-back push-dev push-prod run-front-dev local-build local-run swagger-gen swagger-open scalar-open clean full-clean
 
+GREEN  := \033[0;32m
+RED    := \033[0;31m
+RESET  := \033[0m
+
 # Show available targets
 help:
 	@echo "Usage: make <target>"
@@ -156,18 +160,19 @@ build-back:
 build: build-front
 	find server/frontend -mindepth 1 ! -name '.gitkeep' -delete 2>/dev/null || true
 	mkdir -p server/frontend
-	cp -r apps/web/build/* server/frontend/
-	$(MAKE) build-back
+	cp -r apps/web/dist/client/* server/frontend/
+	@$(MAKE) build-back && \
+		printf "$(GREEN)✅ Build succeeded: server/dist/bedrud$(RESET)\n" || \
+		( printf "$(RED)❌ Build failed$(RESET)\n"; exit 1 )
 
 # Build a production-ready compressed distribution
 build-dist: build
-	@echo "Building production binary (linux/amd64)..."
 	@mkdir -p dist
-	@cd server && GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../dist/bedrud ./cmd/bedrud/main.go
-	@echo "Creating compressed archive..."
-	@tar -cJf dist/bedrud_linux_amd64.tar.xz -C dist bedrud
-	@rm dist/bedrud
-	@echo "Distribution ready: dist/bedrud_linux_amd64.tar.xz"
+	@cd server && GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../dist/bedrud ./cmd/bedrud/main.go && \
+		tar -cJf ../dist/bedrud_linux_amd64.tar.xz -C ../dist bedrud && \
+		rm ../dist/bedrud && \
+		printf "$(GREEN)✅ Distribution ready: dist/bedrud_linux_amd64.tar.xz$(RESET)\n" || \
+		( printf "$(RED)❌ Distribution build failed$(RESET)\n"; exit 1 )
 
 # Build Android debug APK
 build-android-debug:
@@ -274,9 +279,10 @@ push-prod:
 local-build: build-front
 	find server/frontend -mindepth 1 ! -name '.gitkeep' -delete 2>/dev/null || true
 	mkdir -p server/frontend
-	cp -r apps/web/build/* server/frontend/
-	cd server && go build -o dist/bedrud ./cmd/bedrud/main.go
-	@echo "\n✅ Single binary ready: server/dist/bedrud"
+	cp -r apps/web/dist/client/* server/frontend/
+	@cd server && go build -o dist/bedrud ./cmd/bedrud/main.go && \
+		printf "$(GREEN)✅ Single binary ready: server/dist/bedrud$(RESET)\n" || \
+		( printf "$(RED)❌ Local build failed$(RESET)\n"; exit 1 )
 	@echo "   Run with: CONFIG_PATH=server/config.local.yaml server/dist/bedrud run"
 
 # Build and run the single binary locally (SQLite + embedded LiveKit)
@@ -292,7 +298,7 @@ clean:
 	@echo "➜ Removing build artifacts..."
 	@rm -rf dist/
 	@rm -rf server/dist/
-	@rm -rf apps/web/build/
+	@rm -rf apps/web/dist/
 	@find server/frontend -mindepth 1 ! -name '.gitkeep' -delete 2>/dev/null || true
 	@rm -rf apps/android/app/build/
 	@rm -rf apps/ios/build/

--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -61,7 +61,6 @@
         "jsdom": "^29.0.1",
         "typescript": "^6.0.2",
         "vite": "^8.0.3",
-        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.2",
       },
     },
@@ -737,8 +736,6 @@
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
-
     "goober": ["goober@2.1.18", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
@@ -1097,8 +1094,6 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
@@ -1146,8 +1141,6 @@
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
-
-    "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -74,7 +74,6 @@
     "jsdom": "^29.0.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.2"
   },
   "pnpm": {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,10 +3,12 @@ import { devtools } from '@tanstack/devtools-vite'
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 const config = defineConfig({
-  plugins: [devtools(), tsconfigPaths({ projects: ['./tsconfig.json'] }), tailwindcss(), tanstackStart(), viteReact()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  plugins: [devtools(), tailwindcss(), tanstackStart(), viteReact()],
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Summary

Fixes the build workflow after the TanStack Start migration. The previous paths were pointing to the old output directory (`apps/web/build/*`), which no longer exists. Updated everything to match TanStack Start's actual output at `apps/web/dist/client/*`.

Also replaced `vite-tsconfig-paths` with Vite's built-in `resolve.tsconfigPaths`. One less dependency to maintain. Native support is the cleaner choice here.

---

## Changes

- **Makefile**: Updated build paths from `apps/web/build/*` → `apps/web/dist/client/*`
- **vite.config.ts**: Removed `vite-tsconfig-paths` plugin, enabled native `resolve.tsconfigPaths: true`
- **package.json / bun.lock**: Removed `vite-tsconfig-paths` dependency
- **Makefile**: Added colored output to build commands for better readability

---

## Type
- [x] Bug fix

---

## Testing
- [x] Tested locally

---

## Checklist
- [x] Tests passing

---

## Related Issues